### PR TITLE
Add a new lightweight way to create plugins

### DIFF
--- a/lib/octopress-ink.rb
+++ b/lib/octopress-ink.rb
@@ -27,8 +27,20 @@ module Octopress
       require 'octopress-ink/commands'
     end
 
+    # Register a new plugin
+    # 
+    # plugin - A subclass of Plugin
+    #
     def self.register_plugin(plugin)
       Plugins.register_plugin(plugin)
+    end
+
+    # Create a new plugin from a configuration hash
+    # 
+    # options - A hash of configuration options.
+    #
+    def self.new_plugin(options)
+      Plugins.register_plugin Plugin, options
     end
 
     def self.version

--- a/lib/octopress-ink/plugin.rb
+++ b/lib/octopress-ink/plugin.rb
@@ -12,8 +12,8 @@ module Octopress
                     :layouts_dir, :stylesheets_dir, :javascripts_dir, :files_dir, :includes_dir, :images_dir,
                     :layouts, :includes, :images, :fonts, :files, :pages, :docs
 
-      def initialize
-        DEFAULT_CONFIG.merge(configuration).each { |k,v| set_config(k,v) }
+      def initialize(options={})
+        DEFAULT_CONFIG.merge(options || configuration).each { |k,v| set_config(k,v) }
 
         @layouts_dir       = 'layouts'
         @files_dir         = 'files'

--- a/lib/octopress-ink/plugins.rb
+++ b/lib/octopress-ink/plugins.rb
@@ -59,8 +59,8 @@ module Octopress
         @site
       end
 
-      def self.register_plugin(plugin)
-        new_plugin = plugin.new
+      def self.register_plugin(plugin, options=nil)
+        new_plugin = plugin.new(options)
 
         case new_plugin.type
         when 'theme'

--- a/test/plugins/awesome-sauce/plugin.rb
+++ b/test/plugins/awesome-sauce/plugin.rb
@@ -1,15 +1,8 @@
 require 'octopress-ink'
 
-class TestPlugin < Octopress::Ink::Plugin
-  def configuration
-    {
-      name:        'Awesome Sauce',
-      slug:        'awesome-sauce',
-      assets_path: File.expand_path(File.dirname(__FILE__)),
-      description: "Test some plugins y'all"
-    }
-  end
-end
-
-Octopress::Ink.register_plugin(TestPlugin)
-
+Octopress::Ink.new_plugin({
+  name:        'Awesome Sauce',
+  slug:        'awesome-sauce',
+  assets_path: File.expand_path(File.dirname(__FILE__)),
+  description: "Test some plugins y'all"
+})

--- a/test/plugins/test-theme/plugin.rb
+++ b/test/plugins/test-theme/plugin.rb
@@ -1,14 +1,8 @@
 require 'octopress-ink'
 
-class TestTheme < Octopress::Ink::Plugin
-  def configuration
-    {
-      type:        "theme",
-      description: "Test theme y'all",
-      name:        "Classic Theme",
-      assets_path:  File.expand_path(File.dirname(__FILE__))
-    }
-  end
-end
-
-Octopress::Ink.register_plugin(TestTheme)
+Octopress::Ink.new_plugin({
+  name:        "Classic Theme",
+  type:        "theme",
+  description: "Test theme y'all",
+  assets_path:  File.expand_path(File.dirname(__FILE__))
+})


### PR DESCRIPTION
I'm proposing that we add a method to Ink that lets people create a new plugin with only a hash. Here's what that looks like:

``` ruby
require 'octopress-ink'

Octopress::Ink.new_plugin({
  name:        'Awesome Sauce',
  slug:        'awesome-sauce',
  assets_path: File.expand_path(File.dirname(__FILE__)),
  description: "Test some plugins y'all"
})
```

Currently people must subclass `Octopress::Ink::Plugin` and then add a method that returns a hash. If this pull request is merged, the only folks who do that will be those who need to override methods of the plugin class. For the large majority of folks, that won't be necessary.

What do you think @parkr?
