### PR TITLE
We must fix pagination for plugin pages

### DIFF
--- a/test/.clash.yml
+++ b/test/.clash.yml
@@ -44,3 +44,9 @@
     - 'cat .git-config-user-name | tr -d "\n" | xargs -0 git config user.name'
     - 'cat .git-config-user-email | tr -d "\n" | xargs -0 git config user.email'
     - 'rm -rf test-theme .git-config-user-name .git-config-user-email'
+-
+  name: Test plugin pagination
+  build: true
+  config:
+    jekyll: _config_pagination.yml
+  compare: _expected/site_paginate _site

--- a/test/_config_pagination.yml
+++ b/test/_config_pagination.yml
@@ -1,0 +1,10 @@
+include_test: foo.html
+exclude:
+  - Gemfile*
+
+url: http://octopress.org
+timezone: America/Chicago
+markdown: redcarpet
+name: Your New Jekyll Site
+source: source_pagination
+paginate: 1

--- a/test/_expected/site_paginate/2014/02/01/test-post.html
+++ b/test/_expected/site_paginate/2014/02/01/test-post.html
@@ -1,0 +1,1 @@
+<p>Test post 2</p>

--- a/test/_expected/site_paginate/2014/02/02/test-post-2.html
+++ b/test/_expected/site_paginate/2014/02/02/test-post-2.html
@@ -1,0 +1,1 @@
+<p>Test post 1</p>

--- a/test/_expected/site_paginate/index.html
+++ b/test/_expected/site_paginate/index.html
@@ -1,0 +1,9 @@
+<div class="posts-index">
+  
+    
+      <p>Test post 1</p>
+
+    
+  
+</div>
+

--- a/test/_expected/site_paginate/page2/index.html
+++ b/test/_expected/site_paginate/page2/index.html
@@ -1,0 +1,9 @@
+<div class="posts-index">
+  
+    
+      <p>Test post 2</p>
+
+    
+  
+</div>
+

--- a/test/_ink_plugins/blog-theme/pages/index.html
+++ b/test/_ink_plugins/blog-theme/pages/index.html
@@ -1,0 +1,14 @@
+---
+---
+<div class="posts-index">
+  {% if site.paginate %}
+    {% for post in paginator.posts %}
+      {{ post.content }}
+    {% endfor %}
+  {% else %}
+    {% for post in site.posts limit: 10 %}
+      {{ post.content }}
+    {% endfor %}
+  {% endif %}
+</div>
+

--- a/test/_ink_plugins/blog-theme/plugin.rb
+++ b/test/_ink_plugins/blog-theme/plugin.rb
@@ -1,0 +1,8 @@
+require 'octopress-ink'
+
+Octopress::Ink.add_plugin({
+  name:        "Blog Theme",
+  type:        "theme",
+  description: "Blog theme y'all",
+  assets_path:  File.expand_path(File.dirname(__FILE__))
+})

--- a/test/source_pagination/_plugins/loader.rb
+++ b/test/source_pagination/_plugins/loader.rb
@@ -1,0 +1,1 @@
+require './_ink_plugins/blog-theme/plugin.rb'

--- a/test/source_pagination/_posts/2014-02-01-test-post.md
+++ b/test/source_pagination/_posts/2014-02-01-test-post.md
@@ -1,0 +1,6 @@
+---
+title: Test Post 2
+---
+
+Test post 2
+

--- a/test/source_pagination/_posts/2014-02-02-test-post-2.md
+++ b/test/source_pagination/_posts/2014-02-02-test-post-2.md
@@ -1,0 +1,5 @@
+---
+title: Test Post 1
+---
+
+Test post 1


### PR DESCRIPTION
Hey @parkr, I've created a branch with a failing test that demonstrates how pagination doesn't work with Octopress Ink plugins. I'd love your help figuring out how to address this major shortcoming. Without pagination Ink is very limited as a useful theming framework.

Here's the scoop. Pagination gets angry if the file isn't named "index.html" and if it doesn't appear in between source and the pagination dir. I honestly don't know why this is a restriction, but that's where my problems are coming from. With Ink plugins, the assets are stored in the gem, elsewhere on the filesystem and so it will never be acceptable as a pagination file.

To see this test fail, run `bundle exec clash 8` which will run the 8th (and final) test in the test suite. which simply builds Jekyll using the `_config_paginate.yml` and reading from to the `source_paginate` directory. The theme index file can be found at `test/_ink_plugins/blog-theme/pages/index.html` and you can monkey patch things in the `test/_ink_plugins/blog-theme/plugin.rb` file if you want to.

I'm happy to answer any questions you have about this feature and I'm happy to try things and push them if you like. Thanks for your help with this. :D