### PR TITLE
remove redundant :version key

### DIFF
--- a/lib/octopress-ink/commands/new.rb
+++ b/lib/octopress-ink/commands/new.rb
@@ -261,7 +261,6 @@ gemspec path: '../'
             gemspec: gemspec,
             gemspec_path: gemspec_path,
             spec_var: gemspec.scan(/(\w+)\.name/).flatten[0],
-            version: gemspec.scan(/version.+=\s+(.+)$/).flatten[0],
             name: gemspec.scan(/name.+['"](.+)['"]/).flatten[0],
             version: version,
             require_version: require_version,


### PR DESCRIPTION
Some versions of ruby warn about having mutliple instances of the same key in a hash.