### PR TITLE
Document the use of :jekyll_plugins group

### DIFF
--- a/assets/docs/working-with-plugins.markdown
+++ b/assets/docs/working-with-plugins.markdown
@@ -10,10 +10,10 @@ If you were going to install the [octopress-codefence](https://github.com/octopr
 
 #### Using Bundler
 
-If you are using [Bundler](http://bundler.io), simply add it to your Gemfile in the `:octopress` group and run `bundle`. Octopress will automatically load the plugin when you build your site.
+If you are using [Bundler](http://bundler.io), simply add it to your Gemfile in the `:jekyll_plugins` group and run `bundle`. Octopress will automatically load the plugin when you build your site.
 
 ```ruby
-group :octopress do
+group :jekyll_plugins do
   gem 'octopress-codefence'
 end
 ```


### PR DESCRIPTION
Octopress and Ink no longer use an `:octopress` group, choosing instead
to use the Jekyll bundler group, `:jekyll_plugins`.