### PR TITLE
bugfix: unknown method 'merged_file_read_opts'

### DIFF
--- a/lib/octopress-ink/jekyll/convertible.rb
+++ b/lib/octopress-ink/jekyll/convertible.rb
@@ -2,7 +2,7 @@ module Octopress
   module Ink
     module Convertible
       include Jekyll::Convertible
-
+      include Jekyll::Utils
       # Read the YAML frontmatter.
       #
       # base - The String path to the dir containing the file.
@@ -12,7 +12,7 @@ module Octopress
       # Returns nothing.
       def read_yaml(base, name, opts = {})
         begin
-          self.content = File.read(File.join(base, name), merged_file_read_opts(opts))
+          self.content = File.read(File.join(base, name), merged_file_read_opts(site, opts))
           if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
             self.content = $POSTMATCH
             self.data = SafeYAML.load($1)


### PR DESCRIPTION
error occur when using newest version of jekyll (3.1.3) and octopress (3.0.11). Maybe should be merged in a separate 3.x.x branch?!
