### PR TITLE
Fix deprecated use of posts

### DIFF
--- a/lib/octopress-ink/jekyll/convertible.rb
+++ b/lib/octopress-ink/jekyll/convertible.rb
@@ -2,6 +2,7 @@ module Octopress
   module Ink
     module Convertible
       include Jekyll::Convertible
+      include Jekyll::Utils
 
       # Read the YAML frontmatter.
       #
@@ -12,7 +13,7 @@ module Octopress
       # Returns nothing.
       def read_yaml(base, name, opts = {})
         begin
-          self.content = File.read(File.join(base, name), merged_file_read_opts(opts))
+          self.content = File.read(File.join(base, name), merged_file_read_opts(site, opts))
           if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
             self.content = $POSTMATCH
             self.data = SafeYAML.load($1)

--- a/lib/octopress-ink/plugin/bootstrap.rb
+++ b/lib/octopress-ink/plugin/bootstrap.rb
@@ -160,7 +160,7 @@ module Octopress
         if lang && Octopress.multilingual?
           !Octopress.site.posts_by_language(lang).empty?
         else
-          !Octopress.site.posts.empty?
+          !Octopress.site.posts.docs.empty?
         end
       end
 
@@ -168,7 +168,7 @@ module Octopress
         if defined?(Octopress::Linkblog) && lang && Octopress.multilingual?
           !Octopress.site.linkposts_by_language(lang).empty?
         else
-          !Octopress.site.posts.select {|p| p.data['linkpost']}.empty?
+          !Octopress.site.posts.docs.select {|p| p.data['linkpost']}.empty?
         end
       end
 


### PR DESCRIPTION
When running the latest version of Ink with Jekyll 3.x, several deprecation warnings are shown.  This fixes the deprecation warnings by following the instructions given.

This fix will break compatibility with Jekyll 2.  It looks like some of the other gems in the Octopress family are doing that, but if it is necessary to remain compatible with both Jekyll 2 and 3, this fix will need to be re-worked somehow.  I'm not sure of the best way to do that, so suggestions are most welcome.

There might be a similar issue in octopress-multilingual, but I haven't used that gem, so can't say for sure.

Fixes #64.
